### PR TITLE
single article GET response fixed

### DIFF
--- a/server/config/custom-environment-variables.json
+++ b/server/config/custom-environment-variables.json
@@ -1,0 +1,3 @@
+{
+    "jwtPrivateKey": "pacome_jwtPrivateKey"
+}

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -1,0 +1,3 @@
+{
+    "jwtPrivateKey": ""
+}

--- a/server/lib/authentication/auth.js
+++ b/server/lib/authentication/auth.js
@@ -1,0 +1,21 @@
+"use strict";
+
+var _jsonwebtoken = _interopRequireDefault(require("jsonwebtoken"));
+
+var _config = _interopRequireDefault(require("config"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+module.exports = (req, res, next) => {
+  const token = req.header("x-auth-token");
+  if (!token) return res.status(401).send("Access denied. No token provided.");
+
+  try {
+    const decoded = _jsonwebtoken.default.verify(token, _config.default.get("jwtPrivateKey"));
+
+    req.user = decoded;
+    next();
+  } catch (ex) {
+    res.status(400).send("Invalid token.");
+  }
+};

--- a/server/lib/authentication/auth.js
+++ b/server/lib/authentication/auth.js
@@ -8,7 +8,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 module.exports = (req, res, next) => {
   const token = req.header("x-auth-token");
-  if (!token) return res.status(401).send("Access denied. No token provided.");
+  if (!token) return res.status(401).send({
+    error: "Access denied. No token provided."
+  });
 
   try {
     const decoded = _jsonwebtoken.default.verify(token, _config.default.get("jwtPrivateKey"));
@@ -16,6 +18,8 @@ module.exports = (req, res, next) => {
     req.user = decoded;
     next();
   } catch (ex) {
-    res.status(400).send("Invalid token.");
+    res.status(400).send({
+      error: "Invalid token."
+    });
   }
 };

--- a/server/lib/controllers/articleController.js
+++ b/server/lib/controllers/articleController.js
@@ -32,33 +32,28 @@ articleController.post = async (req, res) => {
 
 articleController.getOne = async (req, res) => {
   try {
-    const article = await _Article.default.findOne({
+    const singleArticle = {};
+    singleArticle.article = await _Article.default.findOne({
       _id: req.params.id
     });
 
     try {
-      var likes = await _Like.default.find({
+      singleArticle.likes = await _Like.default.find({
         articleID: req.params.id
       });
     } catch {
-      var likes = [];
+      singleArticle.likes = [];
     }
 
     try {
-      var comments = await _Comment.default.find({
+      singleArticle.comments = await _Comment.default.find({
         articleID: req.params.id
       });
     } catch {
-      var comments = [];
+      singleArticle.comments = [];
     }
 
-    article.likes = likes.length;
-    article.comments = comments;
-    res.send({
-      article: article,
-      likes: likes.length,
-      comments: comments
-    });
+    res.send(singleArticle);
   } catch {
     res.status(404);
     res.send({

--- a/server/lib/controllers/articleController.js
+++ b/server/lib/controllers/articleController.js
@@ -7,6 +7,10 @@ exports.default = void 0;
 
 var _Article = _interopRequireDefault(require("../models/Article"));
 
+var _Like = _interopRequireDefault(require("../models/Like"));
+
+var _Comment = _interopRequireDefault(require("../models/Comment"));
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const articleController = {};
@@ -31,7 +35,30 @@ articleController.getOne = async (req, res) => {
     const article = await _Article.default.findOne({
       _id: req.params.id
     });
-    res.send(article);
+
+    try {
+      var likes = await _Like.default.find({
+        articleID: req.params.id
+      });
+    } catch {
+      var likes = [];
+    }
+
+    try {
+      var comments = await _Comment.default.find({
+        articleID: req.params.id
+      });
+    } catch {
+      var comments = [];
+    }
+
+    article.likes = likes.length;
+    article.comments = comments;
+    res.send({
+      article: article,
+      likes: likes.length,
+      comments: comments
+    });
   } catch {
     res.status(404);
     res.send({

--- a/server/lib/controllers/commentController.js
+++ b/server/lib/controllers/commentController.js
@@ -19,8 +19,8 @@ commentController.getAll = async (req, res) => {
 commentController.post = async (req, res) => {
   const comment = new _Comment.default({
     articleID: req.body.articleID,
-    name: req.body.name,
-    email: req.body.email,
+    userID: req.user._id,
+    name: req.user.name,
     commentBody: req.body.commentBody
   });
   await comment.save();
@@ -42,6 +42,12 @@ commentController.getOne = async (req, res) => {
 };
 
 commentController.delete = async (req, res) => {
+  if (!(req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
+    return res.status(401).send({
+      error: 'Unauthorized action.'
+    });
+  }
+
   try {
     await _Comment.default.deleteOne({
       _id: req.params.id

--- a/server/lib/controllers/likeController.js
+++ b/server/lib/controllers/likeController.js
@@ -12,32 +12,45 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const likeController = {};
 
 likeController.getAll = async (req, res) => {
+  if (!(req.user._id == req.params.id || req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
+    return res.status(401).send({
+      error: 'Unauthorized action.'
+    });
+  }
+
   const likes = await _Like.default.find();
   res.send(likes);
 };
 
 likeController.post = async (req, res) => {
   const storedLike = await _Like.default.findOne({
-    email: req.body.email
+    articleID: req.body.articleID,
+    userID: req.user._id
   });
 
   if (storedLike == null) {
     const like = new _Like.default({
       articleID: req.body.articleID,
-      email: req.body.email,
-      likeBool: req.body.likeBool
+      userID: req.user._id
     });
     await like.save();
     res.send(like);
   } else {
     await _Like.default.deleteOne({
-      email: req.body.email
+      articleID: req.body.articleID,
+      userID: req.user._id
     });
     res.status(204).send();
   }
 };
 
 likeController.getOne = async (req, res) => {
+  if (!(req.user._id == req.params.id || req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
+    return res.status(401).send({
+      error: 'Unauthorized action.'
+    });
+  }
+
   try {
     const like = await _Like.default.find({
       articleID: req.params.id
@@ -52,6 +65,12 @@ likeController.getOne = async (req, res) => {
 };
 
 likeController.delete = async (req, res) => {
+  if (!(req.user._id == req.params.id || req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
+    return res.status(401).send({
+      error: 'Unauthorized action.'
+    });
+  }
+
   try {
     await _Like.default.deleteOne({
       _id: req.params.id

--- a/server/lib/controllers/likeController.js
+++ b/server/lib/controllers/likeController.js
@@ -20,7 +20,6 @@ likeController.post = async (req, res) => {
   const storedLike = await _Like.default.findOne({
     email: req.body.email
   });
-  console.log(storedLike);
 
   if (storedLike == null) {
     const like = new _Like.default({

--- a/server/lib/controllers/queryController.js
+++ b/server/lib/controllers/queryController.js
@@ -18,8 +18,9 @@ queryController.getAll = async (req, res) => {
 
 queryController.post = async (req, res) => {
   const query = new _Query.default({
-    name: req.body.name,
-    email: req.body.email,
+    userID: req.user._id,
+    name: req.user.name,
+    email: req.user.email,
     queryBody: req.body.queryBody
   });
   await query.save();
@@ -27,6 +28,12 @@ queryController.post = async (req, res) => {
 };
 
 queryController.delete = async (req, res) => {
+  if (!(req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
+    return res.status(401).send({
+      error: 'Unauthorized action.'
+    });
+  }
+
   try {
     await _Query.default.deleteOne({
       _id: req.params.id

--- a/server/lib/controllers/userController.js
+++ b/server/lib/controllers/userController.js
@@ -1,0 +1,95 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _User = _interopRequireDefault(require("../models/User"));
+
+var _bcrypt = _interopRequireDefault(require("bcrypt"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const userController = {};
+
+userController.post = async (req, res) => {
+  const user = await _User.default.findOne({
+    email: req.body.email
+  });
+
+  if (!user) {
+    return res.status(400).send('Invalid password or Email.');
+  }
+
+  const validPassword = await _bcrypt.default.compare(req.body.password, user.password);
+
+  if (!validPassword) {
+    return res.status(400).send('Invalid Passw0rd or email.');
+  }
+
+  const token = user.generateAuthToken();
+  res.header('x-auth-token', token).send({
+    _id: user._id,
+    name: user.name,
+    email: user.email,
+    membership: user.membership
+  });
+};
+
+userController.postSignup = async (req, res) => {
+  let user = await _User.default.findOne({
+    email: req.body.email
+  });
+  if (user) return res.status(400).send("User already registered.");
+  user = new _User.default({
+    name: req.body.name,
+    email: req.body.email,
+    password: req.body.password,
+    membership: "member"
+  });
+  const salt = await _bcrypt.default.genSalt(10);
+  user.password = await _bcrypt.default.hash(user.password, salt);
+  await user.save();
+  const token = user.generateAuthToken();
+  res.header('x-auth-token', token).send({
+    _id: user._id,
+    name: user.name,
+    email: user.email,
+    membership: user.membership
+  });
+};
+
+userController.promote = async (req, res) => {
+  if (!(req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
+    return res.status(401).send('Unauthorized action.');
+  }
+
+  try {
+    const user = await _User.default.findOne({
+      _id: req.params.id
+    });
+
+    if (user.membership == "member") {
+      user.membership = "admin";
+    } else {
+      user.membership = "member";
+    }
+
+    await user.save();
+    res.send({
+      _id: user._id,
+      name: user.name,
+      email: user.email,
+      membership: user.membership
+    });
+  } catch {
+    res.status(404);
+    res.send({
+      error: "User doesn't exist!"
+    });
+  }
+};
+
+var _default = userController;
+exports.default = _default;

--- a/server/lib/controllers/userController.js
+++ b/server/lib/controllers/userController.js
@@ -41,7 +41,9 @@ userController.postSignup = async (req, res) => {
   let user = await _User.default.findOne({
     email: req.body.email
   });
-  if (user) return res.status(400).send("User already registered.");
+  if (user) return res.status(400).send({
+    error: "Email is already registered by another user."
+  });
   user = new _User.default({
     name: req.body.name,
     email: req.body.email,
@@ -62,7 +64,9 @@ userController.postSignup = async (req, res) => {
 
 userController.promote = async (req, res) => {
   if (!(req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
-    return res.status(401).send('Unauthorized action.');
+    return res.status(401).send({
+      error: 'Unauthorized action.'
+    });
   }
 
   try {
@@ -87,6 +91,109 @@ userController.promote = async (req, res) => {
     res.status(404);
     res.send({
       error: "User doesn't exist!"
+    });
+  }
+};
+
+userController.patch = async (req, res) => {
+  if (!(req.user._id == req.params.id || req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
+    return res.status(401).send({
+      error: 'Unauthorized action.'
+    });
+  }
+
+  try {
+    const user = await _User.default.findOne({
+      _id: req.params.id
+    });
+
+    if (req.body.email) {
+      user.email = req.body.email;
+    }
+
+    if (req.body.password) {
+      user.password = req.body.password;
+    }
+
+    const salt = await _bcrypt.default.genSalt(10);
+    user.password = await _bcrypt.default.hash(user.password, salt);
+    await user.save();
+
+    if (req.user._id == req.params.id) {
+      const token = user.generateAuthToken();
+      res.header('x-auth-token', token);
+    }
+
+    res.send({
+      _id: user._id,
+      name: user.name,
+      email: user.email,
+      membership: user.membership
+    });
+  } catch {
+    res.status(404);
+    res.send({
+      error: "User doesn't exist!"
+    });
+  }
+};
+
+userController.delete = async (req, res) => {
+  if (!(req.user._id == req.params.id || req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
+    return res.status(401).send({
+      error: 'Unauthorized action.'
+    });
+  }
+
+  try {
+    await _User.default.deleteOne({
+      _id: req.params.id
+    });
+    res.status(204).send();
+  } catch {
+    res.status(404);
+    res.send({
+      error: "User doesn't exist!"
+    });
+  }
+};
+
+userController.getOne = async (req, res) => {
+  // if(!((req.user._id == req.params.id) ||(req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+  //   return res.status(401).send({error:'Unauthorized action.'});
+  // }
+  try {
+    const user = await _User.default.findOne({
+      _id: req.params.id
+    });
+    res.send({
+      _id: user._id,
+      name: user.name,
+      email: user.email,
+      membership: user.membership
+    });
+  } catch {
+    res.status(404);
+    res.send({
+      error: "User doesn't exist!"
+    });
+  }
+};
+
+userController.getAll = async (req, res) => {
+  if (!(req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com")) {
+    return res.status(401).send({
+      error: 'Unauthorized action.'
+    });
+  }
+
+  try {
+    const users = await _User.default.find();
+    res.send(users);
+  } catch {
+    res.status(404);
+    res.send({
+      error: "Failed to load all Users' credentials."
     });
   }
 };

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -14,8 +14,13 @@ var _routes = _interopRequireDefault(require("./routes"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+//To configure the jwtPrivateKey, run this in your terminal:
+//(for MAC or LINUX) $ export pacome_jwtPrivateKey=SECURE_KEY
+//(for WINDOWS [CMD]) $ set pacome_jwtPrivateKey=SECURE_KEY
+// where SECURE_KEY can be any string you want.
 if (!_config.default.get('jwtPrivateKey')) {
-  console.error('FATAL ERROR: jwtPrivateKey is not defined.');
+  console.error('FATAL ERROR: jwtPrivateKey is not defined.'); //to avoid the error, refer to the comments above this function definition.
+
   process.exit(1);
 }
 

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -4,6 +4,8 @@ require("core-js/stable");
 
 require("regenerator-runtime/runtime");
 
+var _config = _interopRequireDefault(require("config"));
+
 var _express = _interopRequireDefault(require("express"));
 
 var _mongoose = _interopRequireDefault(require("mongoose"));
@@ -11,6 +13,11 @@ var _mongoose = _interopRequireDefault(require("mongoose"));
 var _routes = _interopRequireDefault(require("./routes"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+if (!_config.default.get('jwtPrivateKey')) {
+  console.error('FATAL ERROR: jwtPrivateKey is not defined.');
+  process.exit(1);
+}
 
 _mongoose.default.connect("mongodb://localhost:27017/acmedb", {
   useNewUrlParser: true

--- a/server/lib/models/Article.js
+++ b/server/lib/models/Article.js
@@ -12,7 +12,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const schema = _mongoose.default.Schema({
   title: String,
   previewImageURL: String,
-  articleBody: String
+  articleBody: String,
+  authorID: String,
+  date: String,
+  subject: String,
+  readingTime: String
 });
 
 var _default = _mongoose.default.model("Article", schema);

--- a/server/lib/models/Comment.js
+++ b/server/lib/models/Comment.js
@@ -11,8 +11,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 const schema = _mongoose.default.Schema({
   articleID: String,
+  userID: String,
   name: String,
-  email: String,
   commentBody: String
 });
 

--- a/server/lib/models/Like.js
+++ b/server/lib/models/Like.js
@@ -11,8 +11,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 const schema = _mongoose.default.Schema({
   articleID: String,
-  email: String,
-  likeBool: Boolean
+  userID: String
 });
 
 var _default = _mongoose.default.model("Like", schema);

--- a/server/lib/models/Query.js
+++ b/server/lib/models/Query.js
@@ -10,6 +10,7 @@ var _mongoose = _interopRequireDefault(require("mongoose"));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const schema = _mongoose.default.Schema({
+  userID: String,
   name: String,
   email: String,
   queryBody: String

--- a/server/lib/models/User.js
+++ b/server/lib/models/User.js
@@ -1,0 +1,36 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _mongoose = _interopRequireDefault(require("mongoose"));
+
+var _config = _interopRequireDefault(require("config"));
+
+var _jsonwebtoken = _interopRequireDefault(require("jsonwebtoken"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const schema = new _mongoose.default.Schema({
+  name: String,
+  email: String,
+  password: String,
+  membership: String
+});
+
+schema.methods.generateAuthToken = function () {
+  const token = _jsonwebtoken.default.sign({
+    _id: this._id,
+    name: this.name,
+    email: this.email,
+    membership: this.membership
+  }, _config.default.get('jwtPrivateKey'));
+
+  return token;
+};
+
+var _default = _mongoose.default.model("User", schema);
+
+exports.default = _default;

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -30,33 +30,37 @@ const router = _express.default.Router();
 ///////////////////////////////////////////////////////////////////////////////////////////
 router.post("/signin", (0, _middleware.default)(_schemas.default.user), _userController.default.post);
 router.post("/signup", (0, _middleware.default)(_schemas.default.user), _userController.default.postSignup);
-router.patch("/promote/:id", _auth.default, _userController.default.promote); //////////////////////////////////////////////////////////////////////////////////////////////
+router.patch("/promote/:id", _auth.default, _userController.default.promote);
+router.patch("/changecreds/:id", _auth.default, _userController.default.patch);
+router.delete("/deleteuser/:id", _auth.default, _userController.default.delete);
+router.get("/users/:id", _userController.default.getOne);
+router.get("/users/", _auth.default, _userController.default.getAll); //////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 router.get("/queries", _auth.default, _queryController.default.getAll);
-router.post("/queries", (0, _middleware.default)(_schemas.default.query), _queryController.default.post);
+router.post("/queries", _auth.default, (0, _middleware.default)(_schemas.default.query), _queryController.default.post);
 router.delete("/queries/:id", _auth.default, _queryController.default.delete); //////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 router.get("/articles", _articleController.default.getAll);
-router.post("/articles", (0, _middleware.default)(_schemas.default.article), _articleController.default.post);
+router.post("/articles", _auth.default, (0, _middleware.default)(_schemas.default.article), _articleController.default.post);
 router.get("/articles/:id", _articleController.default.getOne);
-router.patch("/articles/:id", (0, _middleware.default)(_schemas.default.article), _articleController.default.patch);
-router.delete("/articles/:id", _articleController.default.delete); //////////////////////////////////////////////////////////////////////////////////////////////
+router.patch("/articles/:id", _auth.default, (0, _middleware.default)(_schemas.default.articlePatch), _articleController.default.patch);
+router.delete("/articles/:id", _auth.default, _articleController.default.delete); //////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 router.get("/comments", _commentController.default.getAll);
-router.post("/comments", (0, _middleware.default)(_schemas.default.comment), _commentController.default.post);
+router.post("/comments", _auth.default, (0, _middleware.default)(_schemas.default.comment), _commentController.default.post);
 router.get("/comments/:id", _commentController.default.getOne); //this will route to ALL COMMENTS on the article associated with the ID.
 
-router.delete("/comments/:id", _commentController.default.delete); //////////////////////////////////////////////////////////////////////////////////////////////
+router.delete("/comments/:id", _auth.default, _commentController.default.delete); //////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-router.get("/likes", _likeController.default.getAll);
-router.post("/likes", (0, _middleware.default)(_schemas.default.like), _likeController.default.post);
-router.get("/likes/:id", _likeController.default.getOne); //this will route to ALL LIKES on the article associated with the ID.
+router.get("/likes", _auth.default, _likeController.default.getAll);
+router.post("/likes", _auth.default, (0, _middleware.default)(_schemas.default.like), _likeController.default.post);
+router.get("/likes/:id", _auth.default, _likeController.default.getOne); //this will route to ALL LIKES on the article associated with the ID.
 
-router.delete("/likes/:id", _likeController.default.delete); //////////////////////////////////////////////////////////////////////////////////////////////
+router.delete("/likes/:id", _auth.default, _likeController.default.delete); //////////////////////////////////////////////////////////////////////////////////////////////
 
 var _default = router;
 exports.default = _default;

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -15,18 +15,27 @@ var _commentController = _interopRequireDefault(require("./controllers/commentCo
 
 var _likeController = _interopRequireDefault(require("./controllers/likeController"));
 
+var _userController = _interopRequireDefault(require("./controllers/userController"));
+
 var _schemas = _interopRequireDefault(require("./validation/schemas"));
 
 var _middleware = _interopRequireDefault(require("./validation/middleware"));
+
+var _auth = _interopRequireDefault(require("./authentication/auth"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const router = _express.default.Router();
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-router.get("/queries", _queryController.default.getAll);
+router.post("/signin", (0, _middleware.default)(_schemas.default.user), _userController.default.post);
+router.post("/signup", (0, _middleware.default)(_schemas.default.user), _userController.default.postSignup);
+router.patch("/promote/:id", _auth.default, _userController.default.promote); //////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////
+
+router.get("/queries", _auth.default, _queryController.default.getAll);
 router.post("/queries", (0, _middleware.default)(_schemas.default.query), _queryController.default.post);
-router.delete("/queries/:id", _queryController.default.delete); //////////////////////////////////////////////////////////////////////////////////////////////
+router.delete("/queries/:id", _auth.default, _queryController.default.delete); //////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 router.get("/articles", _articleController.default.getAll);

--- a/server/lib/validation/middleware.js
+++ b/server/lib/validation/middleware.js
@@ -23,8 +23,6 @@ const middleware = schema => {
         details
       } = error;
       const message = details.map(i => i.message).join(',');
-      console.log("error", message);
-      console.log(req.body);
       res.status(422).json({
         error: message
       });

--- a/server/lib/validation/schemas.js
+++ b/server/lib/validation/schemas.js
@@ -10,6 +10,11 @@ var _joi = _interopRequireDefault(require("joi"));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const schemas = {
+  user: _joi.default.object().keys({
+    name: _joi.default.string(),
+    email: _joi.default.string().required(),
+    password: _joi.default.string().required()
+  }),
   article: _joi.default.object().keys({
     title: _joi.default.string().required(),
     previewImageURL: _joi.default.string().required(),

--- a/server/lib/validation/schemas.js
+++ b/server/lib/validation/schemas.js
@@ -20,21 +20,21 @@ const schemas = {
     previewImageURL: _joi.default.string().required(),
     articleBody: _joi.default.string().required()
   }),
+  articlePatch: _joi.default.object().keys({
+    title: _joi.default.string(),
+    previewImageURL: _joi.default.string(),
+    articleBody: _joi.default.string(),
+    subject: _joi.default.string()
+  }),
   query: _joi.default.object().keys({
-    name: _joi.default.string().required(),
-    email: _joi.default.string().required(),
     queryBody: _joi.default.string().required()
   }),
   comment: _joi.default.object().keys({
     articleID: _joi.default.string().required(),
-    name: _joi.default.string().required(),
-    email: _joi.default.string().required(),
     commentBody: _joi.default.string().required()
   }),
   like: _joi.default.object().keys({
-    articleID: _joi.default.string().required(),
-    email: _joi.default.string().required(),
-    likeBool: _joi.default.boolean().required()
+    articleID: _joi.default.string().required()
   }) // future schemas will be defined here below ...
 
 };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,9 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^5.0.1",
+        "config": "^3.3.7",
         "core-js": "^3.21.1",
         "express": "^4.17.3",
         "joi": "^17.6.0",
+        "jsonwebtoken": "^8.5.1",
         "mongoose": "^6.2.10"
       },
       "devDependencies": {
@@ -1643,6 +1646,61 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
+      "integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -1687,6 +1745,11 @@
         "@types/webidl-conversions": "*"
       }
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1697,6 +1760,25 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1723,6 +1805,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/array-flatten": {
@@ -1781,8 +1880,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1802,6 +1900,19 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcrypt": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.0.1.tgz",
+      "integrity": "sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "node-addon-api": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1850,7 +1961,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1932,6 +2042,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2011,6 +2126,14 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2026,6 +2149,14 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2038,8 +2169,23 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/config": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.3.7.tgz",
+      "integrity": "sha512-mX/n7GKDYZMqvvkY6e6oBY49W8wxdmQt+ho/5lhwFDXqQW9gI+Ahp8EKp8VAbISPnmf2+Bv5uZK7lKXZ6pf1aA==",
+      "dependencies": {
+        "json5": "^2.1.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2162,6 +2308,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "node_modules/denque": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
@@ -2183,6 +2334,22 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2193,6 +2360,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
       "integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
       "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -2373,6 +2545,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -2382,8 +2565,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -2404,6 +2586,25 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -2432,7 +2633,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2503,6 +2703,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
     "node_modules/http-errors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -2516,6 +2721,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -2552,7 +2769,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2609,6 +2825,14 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2668,12 +2892,59 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kareem": {
@@ -2686,6 +2957,52 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/make-dir": {
       "version": "2.1.0",
@@ -2770,12 +3087,45 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mongodb": {
@@ -2862,11 +3212,68 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
       "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
       "dev": true
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2874,6 +3281,25 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2920,7 +3346,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2937,7 +3362,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3032,6 +3456,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -3141,11 +3578,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -3228,6 +3678,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -3237,6 +3692,11 @@
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.0.tgz",
       "integrity": "sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ=="
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/slash": {
       "version": "2.0.0",
@@ -3295,6 +3755,57 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3317,6 +3828,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/to-fast-properties": {
@@ -3420,6 +3947,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -3456,11 +3988,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
@@ -4597,6 +5141,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
+      "integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -4641,6 +5226,11 @@
         "@types/webidl-conversions": "*"
       }
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4649,6 +5239,19 @@
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       }
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -4668,6 +5271,20 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "array-flatten": {
@@ -4717,13 +5334,21 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bcrypt": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.0.1.tgz",
+      "integrity": "sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==",
+      "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "node-addon-api": "^3.1.0"
+      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -4768,7 +5393,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4813,6 +5437,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "bytes": {
       "version": "3.1.2",
@@ -4863,6 +5492,11 @@
         "readdirp": "~3.6.0"
       }
     },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -4878,6 +5512,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+    },
     "commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -4887,8 +5526,20 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "config": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.3.7.tgz",
+      "integrity": "sha512-mX/n7GKDYZMqvvkY6e6oBY49W8wxdmQt+ho/5lhwFDXqQW9gI+Ahp8EKp8VAbISPnmf2+Bv5uZK7lKXZ6pf1aA==",
+      "requires": {
+        "json5": "^2.1.1"
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -4969,6 +5620,11 @@
         "object-keys": "^1.0.12"
       }
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "denque": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
@@ -4984,6 +5640,19 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4994,6 +5663,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
       "integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
       "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -5134,6 +5808,14 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -5143,8 +5825,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -5158,6 +5839,22 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "requires": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -5180,7 +5877,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5227,6 +5923,11 @@
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
     "http-errors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -5237,6 +5938,15 @@
         "setprototypeof": "1.2.0",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.1"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "iconv-lite": {
@@ -5256,7 +5966,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5303,6 +6012,11 @@
       "dev": true,
       "optional": true
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -5347,8 +6061,50 @@
     "json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+    },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "kareem": {
       "version": "2.3.5",
@@ -5360,6 +6116,49 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "make-dir": {
       "version": "2.1.0",
@@ -5422,10 +6221,31 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minipass": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mongodb": {
       "version": "4.3.1",
@@ -5492,11 +6312,53 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
+    "node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-releases": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
       "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
       "dev": true
+    },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -5504,6 +6366,22 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "optional": true
+    },
+    "npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "requires": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -5535,7 +6413,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -5548,8 +6425,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -5614,6 +6490,16 @@
         "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -5704,11 +6590,18 @@
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -5783,6 +6676,11 @@
         "send": "0.17.2"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
     "setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -5792,6 +6690,11 @@
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.0.tgz",
       "integrity": "sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ=="
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "slash": {
       "version": "2.0.0",
@@ -5833,6 +6736,39 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5847,6 +6783,19 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      }
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -5919,6 +6868,11 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -5943,11 +6897,23 @@
         "webidl-conversions": "^7.0.0"
       }
     },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -13,9 +13,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcrypt": "^5.0.1",
+    "config": "^3.3.7",
     "core-js": "^3.21.1",
     "express": "^4.17.3",
     "joi": "^17.6.0",
+    "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.2.10"
   },
   "devDependencies": {

--- a/server/src/authentication/auth.js
+++ b/server/src/authentication/auth.js
@@ -4,13 +4,13 @@ import config from "config";
 module.exports = (req, res, next) => {
 
   const token = req.header("x-auth-token");
-  if (!token) return res.status(401).send("Access denied. No token provided.");
+  if (!token) return res.status(401).send({error: "Access denied. No token provided."});
 
   try {
     const decoded = jwt.verify(token, config.get("jwtPrivateKey"));
     req.user = decoded;
     next();
   } catch (ex) {
-    res.status(400).send("Invalid token.");
+    res.status(400).send({error:"Invalid token."});
   }
 };

--- a/server/src/authentication/auth.js
+++ b/server/src/authentication/auth.js
@@ -1,0 +1,16 @@
+import jwt from "jsonwebtoken";
+import config from "config";
+
+module.exports = (req, res, next) => {
+
+  const token = req.header("x-auth-token");
+  if (!token) return res.status(401).send("Access denied. No token provided.");
+
+  try {
+    const decoded = jwt.verify(token, config.get("jwtPrivateKey"));
+    req.user = decoded;
+    next();
+  } catch (ex) {
+    res.status(400).send("Invalid token.");
+  }
+};

--- a/server/src/controllers/articleController.js
+++ b/server/src/controllers/articleController.js
@@ -37,8 +37,6 @@ articleController.getOne = async (req, res) => {
     } catch {  
       var comments = [];  
     }
-    article.likes = likes.length;
-    article.comments = comments;
     res.send({article: article,likes: likes.length,comments: comments});
 
   } catch {

--- a/server/src/controllers/articleController.js
+++ b/server/src/controllers/articleController.js
@@ -25,19 +25,19 @@ articleController.post = async (req, res) => {
 
 articleController.getOne = async (req, res) => {
   try {
-
-    const article = await Article.findOne({ _id: req.params.id });
+    const singleArticle = {};
+    singleArticle.article = await Article.findOne({ _id: req.params.id });
     try {
-      var likes = await Like.find({ articleID: req.params.id });
+      singleArticle.likes = await Like.find({ articleID: req.params.id });
     } catch {
-      var likes = [];  
+      singleArticle.likes = [];  
     }
     try {
-      var comments = await Comment.find({ articleID: req.params.id });  
+      singleArticle.comments = await Comment.find({ articleID: req.params.id });  
     } catch {  
-      var comments = [];  
+      singleArticle.comments = [];  
     }
-    res.send({article: article,likes: likes.length,comments: comments});
+    res.send(singleArticle);
 
   } catch {
 

--- a/server/src/controllers/articleController.js
+++ b/server/src/controllers/articleController.js
@@ -1,4 +1,6 @@
 import Article from "../models/Article";
+import Like from "../models/Like";
+import Comment from "../models/Comment";
 
 const articleController = {};
 
@@ -25,7 +27,19 @@ articleController.getOne = async (req, res) => {
   try {
 
     const article = await Article.findOne({ _id: req.params.id });
-    res.send(article);
+    try {
+      var likes = await Like.find({ articleID: req.params.id });
+    } catch {
+      var likes = [];  
+    }
+    try {
+      var comments = await Comment.find({ articleID: req.params.id });  
+    } catch {  
+      var comments = [];  
+    }
+    article.likes = likes.length;
+    article.comments = comments;
+    res.send({article: article,likes: likes.length,comments: comments});
 
   } catch {
 

--- a/server/src/controllers/articleController.js
+++ b/server/src/controllers/articleController.js
@@ -12,11 +12,19 @@ articleController.getAll = async (req, res) => {
 };
 
 articleController.post = async (req, res) => {
-
+  if(!((req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send('Unauthorized action.');
+  }
+  const today = new Date();
   const article = new Article({
     title: req.body.title,
     previewImageURL : req.body.previewImageURL,
-    articleBody: req.body.articleBody
+    articleBody: req.body.articleBody,
+    authorID: req.user._id,
+    date: JSON.stringify(today.toJSON()),
+    subject: "TECH NEWS",
+    readingTime: Math.ceil((req.body.articleBody.split(" ")).length * 7.7 /1000) + " MIN"
+
   });
 
   await article.save();
@@ -27,6 +35,9 @@ articleController.getOne = async (req, res) => {
   try {
     const singleArticle = {};
     singleArticle.article = await Article.findOne({ _id: req.params.id });
+    if(!singleArticle.article){
+      throw Error;
+    }
     try {
       singleArticle.likes = await Like.find({ articleID: req.params.id });
     } catch {
@@ -48,6 +59,9 @@ articleController.getOne = async (req, res) => {
 };
 
 articleController.patch = async (req, res) => {
+  if(!((req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send('Unauthorized action.');
+  }
   try {
     const article = await Article.findOne({ _id: req.params.id });
 
@@ -61,6 +75,10 @@ articleController.patch = async (req, res) => {
 
     if (req.body.articleBody) {
       article.articleBody = req.body.articleBody;
+      article.readingTime = Math.ceil((req.body.articleBody.split(" ")).length * 7.7 /1000) + " MIN";
+    }
+    if (req.body.subject) {
+      article.subject = req.body.subject;
     }
 
     await article.save();
@@ -75,6 +93,9 @@ articleController.patch = async (req, res) => {
 };
 
 articleController.delete = async (req, res) => {
+  if(!((req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send('Unauthorized action.');
+  }
   try {
 
     await Article.deleteOne({ _id: req.params.id });

--- a/server/src/controllers/commentController.js
+++ b/server/src/controllers/commentController.js
@@ -13,8 +13,8 @@ commentController.post = async (req, res) => {
 
   const comment = new Comment({
     articleID: req.body.articleID,
-    name: req.body.name,
-    email : req.body.email,
+    userID: req.user._id,
+    name: req.user.name,
     commentBody: req.body.commentBody
   });
 
@@ -38,6 +38,9 @@ commentController.getOne = async (req, res) => {
 
 
 commentController.delete = async (req, res) => {
+  if(!((req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send({error:'Unauthorized action.'});
+  }
   try {
 
     await Comment.deleteOne({ _id: req.params.id });

--- a/server/src/controllers/likeController.js
+++ b/server/src/controllers/likeController.js
@@ -12,7 +12,6 @@ likeController.getAll = async (req, res) => {
 likeController.post = async (req, res) => {
 
   const storedLike = await Like.findOne({ email: req.body.email });
-  console.log(storedLike);
   if(storedLike == null){
     const like = new Like({
       articleID: req.body.articleID,

--- a/server/src/controllers/likeController.js
+++ b/server/src/controllers/likeController.js
@@ -3,7 +3,9 @@ import Like from "../models/Like";
 const likeController = {};
 
 likeController.getAll = async (req, res) => {
-
+  if(!(req.user._id == req.params.id || (req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+      return res.status(401).send({error:'Unauthorized action.'});
+  }
   const likes = await Like.find();
   res.send(likes);
 
@@ -11,25 +13,33 @@ likeController.getAll = async (req, res) => {
 
 likeController.post = async (req, res) => {
 
-  const storedLike = await Like.findOne({ email: req.body.email });
+  const storedLike = await Like.findOne({ 
+    articleID: req.body.articleID,
+    userID : req.user._id  
+  });
   if(storedLike == null){
     const like = new Like({
       articleID: req.body.articleID,
-      email : req.body.email,
-      likeBool: req.body.likeBool
+      userID : req.user._id
     });
   
     await like.save();
     res.send(like);
   }
   else{
-    await Like.deleteOne({ email: req.body.email });
+    await Like.deleteOne({ 
+      articleID: req.body.articleID,
+      userID : req.user._id 
+    });
     res.status(204).send();
   }
   
 };
 
 likeController.getOne = async (req, res) => {
+  if(!(req.user._id == req.params.id || (req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send({error:'Unauthorized action.'});
+  }
   try {
 
     const like = await Like.find({ articleID: req.params.id });
@@ -45,6 +55,9 @@ likeController.getOne = async (req, res) => {
 
 
 likeController.delete = async (req, res) => {
+  if(!(req.user._id == req.params.id || (req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send({error:'Unauthorized action.'});
+  }
   try {
 
     await Like.deleteOne({ _id: req.params.id });

--- a/server/src/controllers/queryController.js
+++ b/server/src/controllers/queryController.js
@@ -10,10 +10,10 @@ queryController.getAll = async (req, res) => {
 };
 
 queryController.post = async (req, res) => {
-
   const query = new Query({
-    name: req.body.name,
-    email : req.body.email,
+    userID : req.user._id,
+    name: req.user.name,
+    email : req.user.email,
     queryBody: req.body.queryBody
   });
 
@@ -23,6 +23,9 @@ queryController.post = async (req, res) => {
 
 
 queryController.delete = async (req, res) => {
+  if(!((req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send({error:'Unauthorized action.'});
+  }
   try {
 
     await Query.deleteOne({ _id: req.params.id });

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -28,7 +28,7 @@ userController.post = async (req, res) => {
 userController.postSignup = async (req, res) => {
 
   let user = await User.findOne({ email: req.body.email });
-  if (user) return res.status(400).send("User already registered.");
+  if (user) return res.status(400).send({ error: "Email is already registered by another user." });
 
   user = new User({
     name: req.body.name,
@@ -52,7 +52,7 @@ userController.postSignup = async (req, res) => {
 
 userController.promote = async (req, res) => {
   if(!(req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" )){
-    return res.status(401).send('Unauthorized action.');
+    return res.status(401).send({error:'Unauthorized action.'});
   }
   try{
     const user = await User.findOne({ _id: req.params.id });
@@ -77,6 +77,93 @@ userController.promote = async (req, res) => {
   }
 
 };
+
+userController.patch = async (req, res) => {
+  if(!(req.user._id == req.params.id || (req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send({error:'Unauthorized action.'});
+  }
+  try{
+    const user = await User.findOne({ _id: req.params.id });
+
+    if(req.body.email){
+      user.email = req.body.email;
+    }
+    if(req.body.password){
+      user.password = req.body.password;
+    }
+    const salt = await bcrypt.genSalt(10);
+    user.password = await bcrypt.hash(user.password, salt);
+
+    await user.save();
+    
+    if(req.user._id == req.params.id){
+      const token = user.generateAuthToken();
+      res.header('x-auth-token',token)
+    }
+
+    res.send({
+      _id: user._id,
+      name: user.name,
+      email: user.email, 
+      membership: user.membership
+    });
+  }
+  catch{
+    res.status(404);
+    res.send({ error: "User doesn't exist!" });
+  }
+
+};
+
+userController.delete = async (req, res) => {
+  if(!(req.user._id == req.params.id || (req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send({error:'Unauthorized action.'});
+  }
+  try{
+    await User.deleteOne({ _id: req.params.id });
+    res.status(204).send();
+  }
+  catch{
+    res.status(404);
+    res.send({ error: "User doesn't exist!" });
+  }
+
+};
+
+userController.getOne = async (req, res) => {
+  // if(!((req.user._id == req.params.id) ||(req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+  //   return res.status(401).send({error:'Unauthorized action.'});
+  // }
+  try{
+    const user = await User.findOne({ _id: req.params.id });
+    res.send({
+      _id: user._id,
+      name: user.name,
+      email: user.email, 
+      membership: user.membership
+    });
+  }
+  catch{
+    res.status(404);
+    res.send({ error: "User doesn't exist!" });
+  }
+
+}
+
+userController.getAll = async (req, res) => {
+  if(!((req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" ))){
+    return res.status(401).send({error:'Unauthorized action.'});
+  }
+  try{
+    const users = await User.find();
+    res.send(users);
+  }
+  catch{
+    res.status(404);
+    res.send({ error: "Failed to load all Users' credentials." });
+  }
+
+}
 
 
 

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -1,0 +1,85 @@
+import User from "../models/User";
+import bcrypt from "bcrypt";
+
+const userController = {};
+
+
+userController.post = async (req, res) => {
+
+  const user = await User.findOne({ email: req.body.email });
+  if (!user) {
+    return res.status(400).send('Invalid password or Email.');
+  }
+
+  const validPassword = await bcrypt.compare(req.body.password, user.password);
+  if (!validPassword) {
+    return res.status(400).send('Invalid Passw0rd or email.');
+  }
+
+  const token = user.generateAuthToken();
+  res.header('x-auth-token',token).send({
+    _id: user._id,
+    name: user.name,
+    email: user.email, 
+    membership: user.membership
+  });
+};
+
+userController.postSignup = async (req, res) => {
+
+  let user = await User.findOne({ email: req.body.email });
+  if (user) return res.status(400).send("User already registered.");
+
+  user = new User({
+    name: req.body.name,
+    email : req.body.email,
+    password: req.body.password,
+    membership: "member"
+  });
+
+  const salt = await bcrypt.genSalt(10);
+  user.password = await bcrypt.hash(user.password, salt);
+  await user.save();
+
+  const token = user.generateAuthToken();
+  res.header('x-auth-token',token).send({
+    _id: user._id,
+    name: user.name,
+    email: user.email, 
+    membership: user.membership
+  });
+};
+
+userController.promote = async (req, res) => {
+  if(!(req.user.membership == "admin" || req.user.email == "smbonimpa2011@gmail.com" )){
+    return res.status(401).send('Unauthorized action.');
+  }
+  try{
+    const user = await User.findOne({ _id: req.params.id });
+
+    if(user.membership == "member"){
+      user.membership = "admin";
+    }
+    else{
+      user.membership = "member";
+    }
+    await user.save();
+    res.send({
+      _id: user._id,
+      name: user.name,
+      email: user.email, 
+      membership: user.membership
+    });
+  }
+  catch{
+    res.status(404);
+    res.send({ error: "User doesn't exist!" });
+  }
+
+};
+
+
+
+export default userController;
+
+

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,9 +1,14 @@
 import "core-js/stable";
 import "regenerator-runtime/runtime";
+import config from "config";
 import express from "express";
 import mongoose from "mongoose";
 import routes from "./routes";
 
+if (!config.get('jwtPrivateKey')) {
+  console.error('FATAL ERROR: jwtPrivateKey is not defined.');
+  process.exit(1);
+}
 
 mongoose.connect("mongodb://localhost:27017/acmedb", { useNewUrlParser: true })
   .then(() => {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -5,8 +5,13 @@ import express from "express";
 import mongoose from "mongoose";
 import routes from "./routes";
 
+//To configure the jwtPrivateKey, run this in your terminal:
+//(for MAC or LINUX) $ export pacome_jwtPrivateKey=SECURE_KEY
+//(for WINDOWS [CMD]) $ set pacome_jwtPrivateKey=SECURE_KEY
+// where SECURE_KEY can be any string you want.
+
 if (!config.get('jwtPrivateKey')) {
-  console.error('FATAL ERROR: jwtPrivateKey is not defined.');
+  console.error('FATAL ERROR: jwtPrivateKey is not defined.'); //to avoid the error, refer to the comments above this function definition.
   process.exit(1);
 }
 

--- a/server/src/models/Article.js
+++ b/server/src/models/Article.js
@@ -5,7 +5,11 @@ const schema = mongoose.Schema({
 
   title: String,
   previewImageURL: String,
-  articleBody: String
+  articleBody: String,
+  authorID: String,
+  date: String,
+  subject: String,
+  readingTime: String,
 
 });
 

--- a/server/src/models/Comment.js
+++ b/server/src/models/Comment.js
@@ -3,8 +3,8 @@ import mongoose from "mongoose";
 
 const schema = mongoose.Schema({
   articleID: String,
+  userID: String,
   name: String,
-  email: String,
   commentBody: String
 
 });

--- a/server/src/models/Like.js
+++ b/server/src/models/Like.js
@@ -3,8 +3,7 @@ import mongoose from "mongoose";
 
 const schema = mongoose.Schema({
   articleID: String,
-  email: String,
-  likeBool: Boolean
+  userID: String,
 
 });
 

--- a/server/src/models/Query.js
+++ b/server/src/models/Query.js
@@ -2,7 +2,7 @@ import mongoose from "mongoose";
 
 
 const schema = mongoose.Schema({
-
+  userID: String,
   name: String,
   email: String,
   queryBody: String

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -1,0 +1,19 @@
+import mongoose from "mongoose";
+import config from "config";
+import jwt from "jsonwebtoken";
+
+const schema = new mongoose.Schema({
+
+  name: String,
+  email: String,
+  password: String,
+  membership: String
+
+});
+
+schema.methods.generateAuthToken = function (){
+  const token = jwt.sign({ _id: this._id,name: this.name, email: this.email, membership: this.membership}, config.get('jwtPrivateKey'));
+  return token;
+}
+
+export default mongoose.model("User", schema);

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -15,47 +15,46 @@ import auth from './authentication/auth';
 router.post("/signin", middleware(schemas.user) , userController.post);
 router.post("/signup", middleware(schemas.user) , userController.postSignup);
 router.patch("/promote/:id", auth , userController.promote);
-
-
+router.patch("/changecreds/:id", auth , userController.patch);
+router.delete("/deleteuser/:id", auth , userController.delete);
+router.get("/users/:id", userController.getOne);
+router.get("/users/", auth , userController.getAll);
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 router.get("/queries", auth, queryController.getAll);
-router.post("/queries", middleware(schemas.query) , queryController.post);
+router.post("/queries", auth, middleware(schemas.query) , queryController.post);
 router.delete("/queries/:id", auth, queryController.delete);
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 
-
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 router.get("/articles", articleController.getAll);
-router.post("/articles", middleware(schemas.article) , articleController.post);
+router.post("/articles",auth , middleware(schemas.article) , articleController.post);
 router.get("/articles/:id", articleController.getOne);
-router.patch("/articles/:id", middleware(schemas.article) , articleController.patch);
-router.delete("/articles/:id", articleController.delete);
+router.patch("/articles/:id",auth , middleware(schemas.articlePatch) , articleController.patch);
+router.delete("/articles/:id",auth , articleController.delete);
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 router.get("/comments", commentController.getAll);
-router.post("/comments", middleware(schemas.comment) , commentController.post);
+router.post("/comments",auth, middleware(schemas.comment) , commentController.post);
 router.get("/comments/:id", commentController.getOne);  //this will route to ALL COMMENTS on the article associated with the ID.
-router.delete("/comments/:id", commentController.delete);
+router.delete("/comments/:id",auth, commentController.delete);
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 
-
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-router.get("/likes", likeController.getAll);
-router.post("/likes", middleware(schemas.like) , likeController.post);
-router.get("/likes/:id", likeController.getOne); //this will route to ALL LIKES on the article associated with the ID.
-router.delete("/likes/:id", likeController.delete);
+router.get("/likes",auth, likeController.getAll);
+router.post("/likes",auth, middleware(schemas.like) , likeController.post);
+router.get("/likes/:id",auth, likeController.getOne); //this will route to ALL LIKES on the article associated with the ID.
+router.delete("/likes/:id",auth, likeController.delete);
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -3,15 +3,28 @@ import articleController from "./controllers/articleController";
 import queryController from "./controllers/queryController";
 import commentController from "./controllers/commentController";
 import likeController from "./controllers/likeController";
+import userController from "./controllers/userController";
 const router = express.Router();
 import schemas from './validation/schemas'; 
 import middleware from './validation/middleware'; 
+import auth from './authentication/auth';
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-router.get("/queries", queryController.getAll);
+router.post("/signin", middleware(schemas.user) , userController.post);
+router.post("/signup", middleware(schemas.user) , userController.postSignup);
+router.patch("/promote/:id", auth , userController.promote);
+
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////////////////
+
+router.get("/queries", auth, queryController.getAll);
 router.post("/queries", middleware(schemas.query) , queryController.post);
-router.delete("/queries/:id", queryController.delete);
+router.delete("/queries/:id", auth, queryController.delete);
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/server/src/validation/middleware.js
+++ b/server/src/validation/middleware.js
@@ -11,9 +11,7 @@ const middleware = (schema) => {
     const { details } = error; 
     const message = details.map(i => i.message).join(',');
  
-    console.log("error", message); 
-    console.log(req.body);
-   res.status(422).json({ error: message }) } 
+    res.status(422).json({ error: message }) } 
   } 
 } 
 

--- a/server/src/validation/schemas.js
+++ b/server/src/validation/schemas.js
@@ -1,6 +1,11 @@
 import Joi from 'joi'; 
 
 const schemas = { 
+  user: Joi.object().keys({ 
+    name: Joi.string(),
+    email: Joi.string().required(),
+    password: Joi.string().required()
+  }) ,
   article: Joi.object().keys({ 
     title: Joi.string().required(),
     previewImageURL: Joi.string().required(),

--- a/server/src/validation/schemas.js
+++ b/server/src/validation/schemas.js
@@ -11,21 +11,21 @@ const schemas = {
     previewImageURL: Joi.string().required(),
     articleBody: Joi.string().required()
   }) ,
-  query: Joi.object().keys({ 
-    name: Joi.string().required(),
-    email: Joi.string().required(),
+  articlePatch: Joi.object().keys({ 
+    title: Joi.string(),
+    previewImageURL: Joi.string(),
+    articleBody: Joi.string(),
+    subject: Joi.string()
+  }) ,
+  query: Joi.object().keys({
     queryBody: Joi.string().required()
   }) ,
   comment: Joi.object().keys({ 
     articleID: Joi.string().required(),
-    name: Joi.string().required(),
-    email: Joi.string().required(),
     commentBody: Joi.string().required()
   }) ,
   like: Joi.object().keys({ 
-    articleID: Joi.string().required(),
-    email: Joi.string().required(),
-    likeBool: Joi.boolean().required()
+    articleID: Joi.string().required()
   }) 
   // future schemas will be defined here below ...
 };


### PR DESCRIPTION
On this branch, I fixed the problem highlighted by the feedback I got (this morning's standup call). The problem was that, when I sent a GET request for a single article, the response did not include likes and comments.
I've edited the `.src/articleController.js` file, so that the `articleController.getOne()` method may give a response which is a JS object consisting of the article (and its properties), the number of likes and the comments (and their properties)